### PR TITLE
Call apt-get update before apt-get install

### DIFF
--- a/installlinux.sh
+++ b/installlinux.sh
@@ -4,6 +4,7 @@ SCRIPT_DIR=$(dirname "$0")
 pushd "$SCRIPT_DIR"
 
 echo Installing gdb..
+sudo apt-get update
 sudo apt-get -y -q install gdb
 sudo `which python` linuxrunner.py -i
 


### PR DESCRIPTION
The `apt-get install` process might fail ([here](https://github.com/pjsip/pjproject/actions/runs/13236068111)) when running on the linux runner.
It is suggested ([here](https://github.com/actions/runner-images/issues/675)) to run `apt-get update` before calling `apt-get install`.
Tests with `apt-get update`:
- https://github.com/trengginas/pjproject_fork/actions/runs/13239363282/job/36951117156