### PR TITLE
Testing with Windows Server 2025 as windows-latest

### DIFF
--- a/.github/workflows/linuxdemo.yml
+++ b/.github/workflows/linuxdemo.yml
@@ -1,6 +1,7 @@
 name: Linux Demo
 on:
   push
+  workflow_dispatch
 jobs:
   success-case:
     runs-on: ubuntu-latest

--- a/.github/workflows/linuxdemo.yml
+++ b/.github/workflows/linuxdemo.yml
@@ -1,7 +1,7 @@
 name: Linux Demo
 on:
-  push
-  workflow_dispatch
+  push:
+  workflow_dispatch:
 jobs:
   success-case:
     runs-on: ubuntu-latest

--- a/.github/workflows/macdemo.yml
+++ b/.github/workflows/macdemo.yml
@@ -1,7 +1,7 @@
 name: Mac Demo
 on:
-  push
-  workflow_dispatch
+  push:
+  workflow_dispatch:
 jobs:
   success-case:
     runs-on: macos-latest

--- a/.github/workflows/macdemo.yml
+++ b/.github/workflows/macdemo.yml
@@ -1,6 +1,7 @@
 name: Mac Demo
 on:
   push
+  workflow_dispatch
 jobs:
   success-case:
     runs-on: macos-latest

--- a/.github/workflows/windowsdemo.yml
+++ b/.github/workflows/windowsdemo.yml
@@ -1,6 +1,7 @@
 name: Windows Demo
 on:
   push
+  workflow_dispatch
 jobs:
   success-case:
     runs-on: windows-latest

--- a/.github/workflows/windowsdemo.yml
+++ b/.github/workflows/windowsdemo.yml
@@ -1,7 +1,7 @@
 name: Windows Demo
 on:
-  push
-  workflow_dispatch
+  push:
+  workflow_dispatch:
 jobs:
   success-case:
     runs-on: windows-latest

--- a/baserunner.py
+++ b/baserunner.py
@@ -170,17 +170,18 @@ class Runner(abc.ABC):
 
         if self.popen.returncode != 0:
             self.info(f'exit code {self.popen.returncode}, waiting until crash dump is written')
-            for _ in range(30):
+            for _ in range(120):
                 if self.detect_crash():
                     break
-                time.sleep(1)
+                time.sleep(5)
 
             if not self.detect_crash():
                 self.err('ERROR: UNABLE TO FIND CRASH DUMP FILE!')
                 dump_dir = self.get_dump_dir()
                 pat = self.get_dump_pattern()
-                files = glob.glob(os.path.join(dump_dir, pat))
-                self.err(f'ls {dump_dir}/{pat}: ' + '  '.join(files[:20]))
+                dump_pat = os.path.join(dump_dir, pat)
+                files = glob.glob(dump_pat)
+                self.err(f'ls {dump_pat}: ' + '  '.join(files[:20]))
             else:
                 self.info(f'crash dump found: {self.get_dump_path()}')
                 time.sleep(5)

--- a/baserunner.py
+++ b/baserunner.py
@@ -83,6 +83,13 @@ class Runner(abc.ABC):
         """
         pass
 
+    @classmethod
+    def list_dump_dirs(cls) -> List[str]:
+        """
+        List directories where dump file is potentially stored.
+        """
+        return [cls.get_dump_dir()]
+    
     @abc.abstractmethod
     def get_dump_path(self) -> str:
         """
@@ -182,6 +189,17 @@ class Runner(abc.ABC):
                 dump_pat = os.path.join(dump_dir, pat)
                 files = glob.glob(dump_pat)
                 self.err(f'ls {dump_pat}: ' + '  '.join(files[:20]))
+                if not files:
+                    self.info("No dump file found")
+                    self.info("Listing contents of common dump directories:")
+                    dirs = self.list_dump_dirs()
+                    for dir in dirs:
+                        dump_pat = os.path.join(dir, pat)
+                        try:
+                            files = glob.glob(dump_pat)
+                        except:
+                            files = ['<dir not found>']
+                        self.err(f'ls {dump_pat}: ' + '  '.join(files[:20]))
             else:
                 self.info(f'crash dump found: {self.get_dump_path()}')
                 time.sleep(5)

--- a/baserunner.py
+++ b/baserunner.py
@@ -173,7 +173,7 @@ class Runner(abc.ABC):
             for _ in range(120):
                 if self.detect_crash():
                     break
-                time.sleep(5)
+                time.sleep(1)
 
             if not self.detect_crash():
                 self.err('ERROR: UNABLE TO FIND CRASH DUMP FILE!')

--- a/installwindows.ps1
+++ b/installwindows.ps1
@@ -1,7 +1,7 @@
 pushd $PSScriptRoot
 
 # Install crash dump registry
-echo Installing crash dump registry
+Write-Host Installing crash dump registry
 Start-Process cmd.exe -Wait -Verb runAs -ArgumentList ("/C", "cd", $(Get-Location), "&&", "reg.exe", "IMPORT", "localdumps.reg")
 
 # Download procdump.exe, check cdb.exe, etc

--- a/installwindows.ps1
+++ b/installwindows.ps1
@@ -1,8 +1,8 @@
 pushd $PSScriptRoot
 
 # Install crash dump registry
-Write-Host Installing crash dump registry
-Start-Process cmd.exe -Wait -Verb runAs -ArgumentList ("/C", "cd", $(Get-Location), "&&", "reg.exe", "IMPORT", "localdumps.reg")
+#Write-Host Installing crash dump registry
+#Start-Process cmd.exe -Wait -Verb runAs -ArgumentList ("/C", "cd", $(Get-Location), "&&", "reg.exe", "IMPORT", "localdumps.reg")
 
 # Download procdump.exe, check cdb.exe, etc
 python winrunner.py -i

--- a/winrunner.py
+++ b/winrunner.py
@@ -104,24 +104,25 @@ class WinRunner(Runner):
         return None
 
     @classmethod
+    def expand_envs(cls, path: str) -> str:
+        pat = r'%([a-zA-Z0-9_]+)%'
+        while True:
+            m = re.search(pat, path, re.I)
+            if m is None:
+                break
+            path = path.replace(f'%{m[1]}%', os.environ[m[1].upper()] )
+        return path
+
+    @classmethod
     def get_dump_dir(cls) -> str:
         """Get the actual path of the dump directory that is installed in the registry"""
-        def expand_envs(path: str) -> str:
-            pat = r'%([a-zA-Z0-9_]+)%'
-            while True:
-                m = re.search(pat, path, re.I)
-                if m is None:
-                    break
-                path = path.replace(f'%{m[1]}%', os.environ[m[1].upper()] )
-            return path
-
         if not cls.dump_path:
             HKLM = winreg.ConnectRegistry(None, winreg.HKEY_LOCAL_MACHINE)
             LD = r'SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps'
             ld = winreg.OpenKey(HKLM, LD)
             path, _ = winreg.QueryValueEx(ld, 'DumpFolder')
             winreg.CloseKey(ld)
-            cls.dump_path = expand_envs(path)
+            cls.dump_path = cls.expand_envs(path)
             cls.info(f'Dump dir is "{cls.dump_path}"')
 
         return cls.dump_path
@@ -137,7 +138,7 @@ class WinRunner(Runner):
     @classmethod
     def list_registry(cls, path: str):
         HKLM = winreg.ConnectRegistry(None, winreg.HKEY_LOCAL_MACHINE)
-        cls.info(f'Dumping reistry "HKLM\\{path}":')
+        cls.info(f'Dumping registry "HKLM\\{path}":')
         try:
             key = winreg.OpenKey(HKLM, path)
         except OSError as e:
@@ -170,7 +171,7 @@ class WinRunner(Runner):
             key = winreg.OpenKey(HKLM, AEDEBUG_PATH, access=winreg.KEY_ALL_ACCESS)
             try:
                 val, _ = winreg.QueryValueEx(key, 'Debugger')
-                if val != '-':
+                if val and val != '-':
                     cls.info(f'Disabling Debugger')
                     winreg.SetValueEx(key, "Debugger", 0, winreg.REG_SZ, "-")
                     winreg.CloseKey(key)
@@ -185,15 +186,16 @@ class WinRunner(Runner):
 
         # Setup registry to tell Windows to create minidump on app crash.
         # https://learn.microsoft.com/en-us/windows/win32/wer/collecting-user-mode-dumps
-        
+
+        LD = r'SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps'
+        cls.list_registry(LD)
+
         dump_dir = None
         try:
             dump_dir = cls.get_dump_dir()
         except OSError as e:
             pass
 
-        LD = r'SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps'
-        cls.list_registry(LD)
         try:
             ld = winreg.OpenKey(HKLM, LD, access=winreg.KEY_ALL_ACCESS)
         except OSError as e:
@@ -201,19 +203,14 @@ class WinRunner(Runner):
             cls.info(f'Registry "LocalDumps" key created')
         
         if not dump_dir:
-            dump_dir = cls.get_dump_dir()
+            DUMP_FOLDER = '%userprofile%\Dumps'
+            cls.info(f'Setting DumpFolder')
+            dump_dir = cls.expand_envs(DUMP_FOLDER)
             if not os.path.exists(dump_dir):
                 os.makedirs(dump_dir)
                 cls.info(f'Directory {dump_dir} created')
-
-            DUMP_FOLDER = '%userprofile%\Dumps'
-            try:
-                val, type = winreg.QueryValueEx(ld, 'DumpFolder')
-            except OSError as e:
-                val, type = '', None
-            if val.lower() != DUMP_FOLDER.lower() or type != winreg.REG_EXPAND_SZ:
-                winreg.SetValueEx(ld, 'DumpFolder', None, winreg.REG_EXPAND_SZ, DUMP_FOLDER)
-                #cls.info(f'Registry "DumpFolder" set to {DUMP_FOLDER}')
+            
+            winreg.SetValueEx(ld, 'DumpFolder', None, winreg.REG_EXPAND_SZ, DUMP_FOLDER)
 
         try:
             val, type = winreg.QueryValueEx(ld, 'DumpType')
@@ -221,12 +218,12 @@ class WinRunner(Runner):
             val, type = -1, None
         MINIDUMP = 1
         if val!=MINIDUMP or type!=winreg.REG_DWORD:
+            cls.info(f'Setting Registry "DumpType" set to {MINIDUMP}')
             winreg.SetValueEx(ld, 'DumpType', None, winreg.REG_DWORD, MINIDUMP)
-            #cls.info(f'Registry "DumpType" set to {MINIDUMP}')
 
         winreg.CloseKey(ld)
         cls.list_registry(LD)
-        
+
         # Check cdb.exe and install if necessary
         errors = []
         cdb_exe = cls.find_cdb()

--- a/winrunner.py
+++ b/winrunner.py
@@ -2,6 +2,7 @@ import datetime
 import glob
 import os
 import platform
+import re
 import shutil
 import subprocess
 import sys
@@ -18,6 +19,7 @@ class WinRunner(Runner):
     """
     Windows runner
     """
+    dump_path: str = None
 
     def __init__(self, path: str, args: List[str], **kwargs):
         super().__init__(path, args, **kwargs)
@@ -104,8 +106,25 @@ class WinRunner(Runner):
     @classmethod
     def get_dump_dir(cls) -> str:
         """Get the actual path of the dump directory that is installed in the registry"""
-        home = os.environ['userprofile']
-        return os.path.abspath( os.path.join(home, 'Dumps') )
+        def expand_envs(path: str) -> str:
+            pat = r'%([a-zA-Z0-9_]+)%'
+            while True:
+                m = re.search(pat, path, re.I)
+                if m is None:
+                    break
+                path = path.replace(f'%{m[1]}%', os.environ[m[1].upper()] )
+            return path
+
+        if not cls.dump_path:
+            HKLM = winreg.ConnectRegistry(None, winreg.HKEY_LOCAL_MACHINE)
+            LD = r'SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps'
+            ld = winreg.OpenKey(HKLM, LD)
+            path, _ = winreg.QueryValueEx(ld, 'DumpFolder')
+            winreg.CloseKey(ld)
+            cls.dump_path = expand_envs(path)
+            cls.info(f'Dump dir is "{cls.dump_path}"')
+
+        return cls.dump_path
 
     @classmethod
     def get_dump_pattern(cls) -> str:
@@ -129,8 +148,9 @@ class WinRunner(Runner):
             key = winreg.OpenKey(HKLM, r'SOFTWARE\Microsoft\Windows NT\CurrentVersion\AeDebug')
             try:
                 val, _ = winreg.QueryValueEx(key, 'Debugger')
-                cls.info(f'  Debugger was "{val}"')
-                winreg.DeleteValue(key, "Debugger")
+                if val != '-':
+                    cls.info(f'  Debugger was "{val}"')
+                    winreg.DeleteValue(key, "Debugger")
             except:
                 pass
             winreg.CloseKey(key)
@@ -140,6 +160,12 @@ class WinRunner(Runner):
         # Setup registry to tell Windows to create minidump on app crash.
         # https://learn.microsoft.com/en-us/windows/win32/wer/collecting-user-mode-dumps
         
+        dump_dir = None
+        try:
+            dump_dir = cls.get_dump_dir()
+        except OSError as e:
+            pass
+
         LD = r'SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps'
         try:
             ld = winreg.OpenKey(HKLM, LD)
@@ -147,22 +173,23 @@ class WinRunner(Runner):
             ld = winreg.CreateKey(HKLM, LD)
             cls.info(f'Registry "LocalDumps" key created')
         
-        dump_dir = cls.get_dump_dir()
-        if not os.path.exists(dump_dir):
-            os.makedirs(dump_dir)
-            cls.info(f'Directory {dump_dir} created')
+        if not dump_dir:
+            dump_dir = cls.get_dump_dir()
+            if not os.path.exists(dump_dir):
+                os.makedirs(dump_dir)
+                cls.info(f'Directory {dump_dir} created')
 
-        DUMP_FOLDER = '%userprofile%\Dumps'
-        try:
-            val, type = winreg.QueryValueEx(ld, 'DumpFolder')
-        except OSError as e:
-            val, type = '', None
-        if val.lower() != DUMP_FOLDER.lower() or type != winreg.REG_EXPAND_SZ:
-            winreg.SetValueEx(ld, 'DumpFolder', None, winreg.REG_EXPAND_SZ, DUMP_FOLDER)
-            #cls.info(f'Registry "DumpFolder" set to {DUMP_FOLDER}')
+            DUMP_FOLDER = '%userprofile%\Dumps'
+            try:
+                val, type = winreg.QueryValueEx(ld, 'DumpFolder')
+            except OSError as e:
+                val, type = '', None
+            if val.lower() != DUMP_FOLDER.lower() or type != winreg.REG_EXPAND_SZ:
+                winreg.SetValueEx(ld, 'DumpFolder', None, winreg.REG_EXPAND_SZ, DUMP_FOLDER)
+                #cls.info(f'Registry "DumpFolder" set to {DUMP_FOLDER}')
 
-        val, _ = winreg.QueryValueEx(ld, 'DumpFolder')
-        cls.info(f'Registry "DumpFolder" is "{val}"')
+            val, _ = winreg.QueryValueEx(ld, 'DumpFolder')
+            cls.info(f'Registry "DumpFolder" is "{val}"')
 
         try:
             val, type = winreg.QueryValueEx(ld, 'DumpType')

--- a/winrunner.py
+++ b/winrunner.py
@@ -131,7 +131,8 @@ class WinRunner(Runner):
         """
         Get file pattern to find dump files
         """
-        return "*.dmp"
+        #return "*.dmp"
+        return "*"
 
     @classmethod
     def install(cls):

--- a/winrunner.py
+++ b/winrunner.py
@@ -143,7 +143,10 @@ class WinRunner(Runner):
             val, type = '', None
         if val.lower() != DUMP_FOLDER.lower() or type != winreg.REG_EXPAND_SZ:
             winreg.SetValueEx(ld, 'DumpFolder', None, winreg.REG_EXPAND_SZ, DUMP_FOLDER)
-            cls.info(f'Registry "DumpFolder" set to {DUMP_FOLDER}')
+            #cls.info(f'Registry "DumpFolder" set to {DUMP_FOLDER}')
+
+        val, _ = winreg.QueryValueEx(ld, 'DumpFolder')
+        cls.info(f'Registry "DumpFolder" is "{val}"')
 
         try:
             val, type = winreg.QueryValueEx(ld, 'DumpType')
@@ -152,8 +155,10 @@ class WinRunner(Runner):
         MINIDUMP = 1
         if val!=MINIDUMP or type!=winreg.REG_DWORD:
             winreg.SetValueEx(ld, 'DumpType', None, winreg.REG_DWORD, MINIDUMP)
-            cls.info(f'Registry "DumpType" set to {MINIDUMP}')
+            #cls.info(f'Registry "DumpType" set to {MINIDUMP}')
 
+        val, _ = winreg.QueryValueEx(ld, 'DumpType')
+        cls.info(f'Registry "DumpType" is {val}')
         winreg.CloseKey(ld)
 
         # Check cdb.exe and install if necessary

--- a/winrunner.py
+++ b/winrunner.py
@@ -128,12 +128,29 @@ class WinRunner(Runner):
         return cls.dump_path
 
     @classmethod
+    def list_dump_dirs(cls) -> List[str]:
+        """
+        List directories where dump file is potentially stored.
+        """
+        dirs = [
+            cls.get_dump_dir(),
+            os.getcwd(),
+            'C:\\Windows\\Minidump',
+            # https://learn.microsoft.com/en-us/windows/win32/wer/collecting-user-mode-dumps
+            cls.expand_envs('%LOCALAPPDATA%\\CrashDumps'),
+            cls.expand_envs('%SystemRoot%\\Minidump'),
+        ]
+
+        dirs = [os.path.abspath(d) for d in dirs]
+        return dirs
+    
+    @classmethod
     def get_dump_pattern(cls) -> str:
         """
         Get file pattern to find dump files
         """
-        #return "*.dmp"
-        return "*"
+        return "*.dmp"
+        #return "*"
 
     @classmethod
     def list_registry(cls, path: str):

--- a/winrunner.py
+++ b/winrunner.py
@@ -135,6 +135,26 @@ class WinRunner(Runner):
         return "*"
 
     @classmethod
+    def list_registry(cls, path: str):
+        HKLM = winreg.ConnectRegistry(None, winreg.HKEY_LOCAL_MACHINE)
+        cls.info(f'Dumping reistry "HKLM\\{path}":')
+        try:
+            key = winreg.OpenKey(HKLM, path)
+        except OSError as e:
+            cls.info("  Not found.")
+            return
+        
+        try:
+            val = winreg.QueryValue(key, None)
+            cls.info(f' - "root": "{val}"')
+            for i in range(20):
+                name, val, type = winreg.EnumValue(key, i)
+                cls.info(f' - "{name}": "{val}" [type={type}]')
+        except OSError as e:
+            pass
+        winreg.CloseKey(key)
+
+    @classmethod
     def install(cls):
         """Requires administrator privilege to write to registry"""
         # For top level overview on user mode exception handling:
@@ -144,17 +164,22 @@ class WinRunner(Runner):
         # https://learn.microsoft.com/en-us/windows/win32/debug/configuring-automatic-debugging
 
         HKLM = winreg.ConnectRegistry(None, winreg.HKEY_LOCAL_MACHINE)
-        cls.info(f'Disabling AeDebug')
+        AEDEBUG_PATH = r'SOFTWARE\Microsoft\Windows NT\CurrentVersion\AeDebug'
+        cls.list_registry(AEDEBUG_PATH)
         try:
-            key = winreg.OpenKey(HKLM, r'SOFTWARE\Microsoft\Windows NT\CurrentVersion\AeDebug')
+            key = winreg.OpenKey(HKLM, AEDEBUG_PATH, access=winreg.KEY_ALL_ACCESS)
             try:
                 val, _ = winreg.QueryValueEx(key, 'Debugger')
                 if val != '-':
-                    cls.info(f'  Debugger was "{val}"')
-                    winreg.DeleteValue(key, "Debugger")
-            except:
-                pass
-            winreg.CloseKey(key)
+                    cls.info(f'Disabling Debugger')
+                    winreg.SetValueEx(key, "Debugger", 0, winreg.REG_SZ, "-")
+                    winreg.CloseKey(key)
+                    key = None
+                    cls.list_registry(AEDEBUG_PATH)
+            except OSError as e:
+                cls.info(f'  Exception: {e}')
+            if key is not None:
+                winreg.CloseKey(key)
         except Exception as e:
             cls.info(f'  Caught exception: {e}')
 
@@ -168,8 +193,9 @@ class WinRunner(Runner):
             pass
 
         LD = r'SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps'
+        cls.list_registry(LD)
         try:
-            ld = winreg.OpenKey(HKLM, LD)
+            ld = winreg.OpenKey(HKLM, LD, access=winreg.KEY_ALL_ACCESS)
         except OSError as e:
             ld = winreg.CreateKey(HKLM, LD)
             cls.info(f'Registry "LocalDumps" key created')
@@ -189,9 +215,6 @@ class WinRunner(Runner):
                 winreg.SetValueEx(ld, 'DumpFolder', None, winreg.REG_EXPAND_SZ, DUMP_FOLDER)
                 #cls.info(f'Registry "DumpFolder" set to {DUMP_FOLDER}')
 
-            val, _ = winreg.QueryValueEx(ld, 'DumpFolder')
-            cls.info(f'Registry "DumpFolder" is "{val}"')
-
         try:
             val, type = winreg.QueryValueEx(ld, 'DumpType')
         except OSError as e:
@@ -201,10 +224,9 @@ class WinRunner(Runner):
             winreg.SetValueEx(ld, 'DumpType', None, winreg.REG_DWORD, MINIDUMP)
             #cls.info(f'Registry "DumpType" set to {MINIDUMP}')
 
-        val, _ = winreg.QueryValueEx(ld, 'DumpType')
-        cls.info(f'Registry "DumpType" is {val}')
         winreg.CloseKey(ld)
-
+        cls.list_registry(LD)
+        
         # Check cdb.exe and install if necessary
         errors = []
         cdb_exe = cls.find_cdb()

--- a/winrunner.py
+++ b/winrunner.py
@@ -117,13 +117,29 @@ class WinRunner(Runner):
     @classmethod
     def install(cls):
         """Requires administrator privilege to write to registry"""
-        
+        # For top level overview on user mode exception handling:
+        # https://learn.microsoft.com/en-us/windows-hardware/drivers/debugger/enabling-postmortem-debugging
 
-        #
+        # Disable automatic debugging (otherwise crash dump will not be created)
+        # https://learn.microsoft.com/en-us/windows/win32/debug/configuring-automatic-debugging
+
+        HKLM = winreg.ConnectRegistry(None, winreg.HKEY_LOCAL_MACHINE)
+        cls.info(f'Disabling AeDebug')
+        try:
+            key = winreg.OpenKey(HKLM, r'SOFTWARE\Microsoft\Windows NT\CurrentVersion\AeDebug')
+            try:
+                val, _ = winreg.QueryValueEx(key, 'Debugger')
+                cls.info(f'  Debugger was "{val}"')
+                winreg.DeleteValue(key, "Debugger")
+            except:
+                pass
+            winreg.CloseKey(key)
+        except Exception as e:
+            cls.info(f'  Caught exception: {e}')
+
         # Setup registry to tell Windows to create minidump on app crash.
         # https://learn.microsoft.com/en-us/windows/win32/wer/collecting-user-mode-dumps
-        #
-        HKLM = winreg.ConnectRegistry(None, winreg.HKEY_LOCAL_MACHINE)
+        
         LD = r'SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps'
         try:
             ld = winreg.OpenKey(HKLM, LD)

--- a/winrunner.py
+++ b/winrunner.py
@@ -32,7 +32,7 @@ class WinRunner(Runner):
         self.procdump_exe = os.path.abspath(self.procdump_exe)
 
     @classmethod
-    def search_cdb(start_dir: str, machine_type: str = None) -> List[str]:
+    def search_cdb(cls, start_dir: str, machine_type: str = None) -> List[str]:
         """
         Find cdb.exe suitable for current platform
         """
@@ -160,6 +160,7 @@ class WinRunner(Runner):
         cdb_exe = cls.find_cdb()
         if not cdb_exe:
             errors.append('cdb.exe not found')
+            cls.info('cdb.exe not found, searching for it..')
             cbds = cls.search_cdb('C:\\')
             if cbds:
                 errors.append(f'However cdb.exe can be found here: {", ".join(cbds)}')

--- a/winrunner.py
+++ b/winrunner.py
@@ -162,7 +162,7 @@ class WinRunner(Runner):
             errors.append('cdb.exe not found')
             cbds = cls.search_cdb('C:\\')
             if cbds:
-                errors.append(f'However cdb.exe can be found here: {"\n".join(cbds)}')
+                errors.append(f'However cdb.exe can be found here: {", ".join(cbds)}')
 
         procdump_exe = cls.find_procdump()
         if not procdump_exe:

--- a/winrunner.py
+++ b/winrunner.py
@@ -32,14 +32,14 @@ class WinRunner(Runner):
         self.procdump_exe = os.path.abspath(self.procdump_exe)
 
     @classmethod
-    def search_cdb(cls, start_dir: str, machine_type: str = None) -> List[str]:
+    def search_cdb(cls, start_dir: str, filter_machine_type = False) -> List[str]:
         """
         Find cdb.exe suitable for current platform
         """
         results = []
         ndirs = 0
 
-        if not machine_type:
+        if filter_machine_type:
             machine_type = platform.machine()
             if machine_type == 'AMD64' or machine_type == 'x86_64':
                 machine_type = 'x64'
@@ -50,9 +50,10 @@ class WinRunner(Runner):
             cdbs = [os.path.join(root, f) for f in files
                     if 'cdb'==f.lower()[:3] and '.exe'==f.lower()[-4:]
                     ]
-            #cdbs = [path for path in cdbs
-            #        if machine_type in path.lower()
-            #        ]
+            if filter_machine_type:
+                cdbs = [path for path in cdbs
+                        if machine_type in path.lower()
+                        ]
             for path in cdbs:
                 print(path)
             results += cdbs
@@ -155,18 +156,18 @@ class WinRunner(Runner):
 
         winreg.CloseKey(ld)
 
-        # Check cdb.exe and procdump.exe
+        # Check cdb.exe and install if necessary
         errors = []
         cdb_exe = cls.find_cdb()
         if not cdb_exe:
-            errors.append('cdb.exe not found')
-            cls.info('cdb.exe not found, searching for it..')
-            cbds = cls.search_cdb('C:\\')
-            if cbds:
-                errors.append(f'Potential cdb.exe or similar file can be found here: {", ".join(cbds)}')
-            else:
-                cls.info('No potential cdb.exe replacement was found')
+            cls.info('Installing cdb..')
+            os.system('choco install windows-sdk-10-version-2004-windbg --yes --no-progress')
 
+            cdb_exe = cls.find_cdb()
+            if not cdb_exe:
+                errors.append('cdb.exe not found')
+
+        # Check procdump
         procdump_exe = cls.find_procdump()
         if not procdump_exe:
             cls.info('Downloading procdump.zip..')

--- a/winrunner.py
+++ b/winrunner.py
@@ -1,6 +1,7 @@
 import datetime
 import glob
 import os
+import platform
 import shutil
 import subprocess
 import sys
@@ -31,6 +32,37 @@ class WinRunner(Runner):
         self.procdump_exe = os.path.abspath(self.procdump_exe)
 
     @classmethod
+    def search_cdb(start_dir: str, machine_type: str = None) -> List[str]:
+        """
+        Find cdb.exe suitable for current platform
+        """
+        results = []
+        ndirs = 0
+
+        if not machine_type:
+            machine_type = platform.machine()
+            if machine_type == 'AMD64' or machine_type == 'x86_64':
+                machine_type = 'x64'
+            else:
+                machine_type = 'x86'
+
+        for root, dirs, files in os.walk(start_dir):
+            cdbs = [os.path.join(root, f) for f in files
+                    if 'cdb.exe' == f.lower()
+                    ]
+            cdbs = [path for path in cdbs
+                    if machine_type in path.lower()
+                    ]
+            for path in cdbs:
+                print(path)
+            results += cdbs
+            ndirs += 1
+
+        #print(f'Walked {ndirs} directories and found {len(results)} result(s)')
+        return results
+
+
+    @classmethod
     def find_cdb(cls) -> str:
         """
         Find cdb.exe (console debugger).
@@ -46,6 +78,7 @@ class WinRunner(Runner):
         for path in CDB_PATHS:
             if os.path.exists(path):
                 return path
+            
         return None
 
     @classmethod
@@ -127,6 +160,9 @@ class WinRunner(Runner):
         cdb_exe = cls.find_cdb()
         if not cdb_exe:
             errors.append('cdb.exe not found')
+            cbds = cls.search_cdb('C:\\')
+            if cbds:
+                errors.append(f'However cdb.exe can be found here: {"\n".join(cbds)}')
 
         procdump_exe = cls.find_procdump()
         if not procdump_exe:

--- a/winrunner.py
+++ b/winrunner.py
@@ -48,11 +48,11 @@ class WinRunner(Runner):
 
         for root, dirs, files in os.walk(start_dir):
             cdbs = [os.path.join(root, f) for f in files
-                    if 'cdb.exe' == f.lower()
+                    if 'cdb'==f.lower()[:3] and '.exe'==f.lower()[-4:]
                     ]
-            cdbs = [path for path in cdbs
-                    if machine_type in path.lower()
-                    ]
+            #cdbs = [path for path in cdbs
+            #        if machine_type in path.lower()
+            #        ]
             for path in cdbs:
                 print(path)
             results += cdbs
@@ -163,7 +163,9 @@ class WinRunner(Runner):
             cls.info('cdb.exe not found, searching for it..')
             cbds = cls.search_cdb('C:\\')
             if cbds:
-                errors.append(f'However cdb.exe can be found here: {", ".join(cbds)}')
+                errors.append(f'Potential cdb.exe or similar file can be found here: {", ".join(cbds)}')
+            else:
+                cls.info('No potential cdb.exe replacement was found')
 
         procdump_exe = cls.find_procdump()
         if not procdump_exe:


### PR DESCRIPTION
Few problems were found on Windows due to recent update to `windows-latest` to use Windows Server 2025 by GH ( https://github.com/actions/runner-images/pull/12677)

- cirunner fails with `cdb.exe not found` 
- (once the above is fixed) also unable to find crash dump on Windows crash case
